### PR TITLE
Room Fix

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -9,4 +9,4 @@ ReactDOM.render(<App />, document.getElementById("root"));
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.
 // Learn more about service workers: https://bit.ly/CRA-PWA
-serviceWorker.register();
+serviceWorker.unregister();

--- a/room.js
+++ b/room.js
@@ -103,7 +103,7 @@ class Room {
         const num = await generateNumber(0, 1000)
         const shuffledCards = shuffle(this.setup.characters, () => num / 1000)
         for (let i = 0; i < shuffledCards.length; i++) {
-            this._assignCharacter(this.players[i], shuffledCards[i])
+            this._assignCharacter(this.players[i].socket, shuffledCards[i])
         }
 
         switch (this.setup.game) {
@@ -133,8 +133,8 @@ const AvalonGamePlayerInfo = [
 const getKnownAvalonPlayers = (knownList, players, deck) => {
     return knownList.reduce((knownNames, name) => {
         const index = deck.findIndex(card => card == name);
-        if (index !== -1 && SocketState.get(players[index].id)) {
-            knownNames.push(SocketState.get(players[index].id).name);
+        if (index !== -1 && SocketState.get(players[index].socket.id)) {
+            knownNames.push(SocketState.get(players[index].socket.id).name);
         }
         return knownNames;
     }, []);
@@ -148,7 +148,7 @@ const AvalonGameInfo = (players, deck, num) => {
             data = getKnownAvalonPlayers(playerData.knows, players, deck);
 
             const shuffledRoles = shuffle(data, () => num / 1000)
-            players[playerIndex].emit('gameInfo', JSON.stringify(shuffledRoles))
+            players[playerIndex].socket.emit('gameInfo', JSON.stringify(shuffledRoles))
         }
     }
 }


### PR DESCRIPTION
### Problem
- Players array is now an object instead of just a socket, references were not updated in all areas.

### Solution
- Updated the areas where it was still treated as just a socket
- Also updated the service worker to unregister so after the next hard reload no one should experience a cached version of the front end

### Testing
- Tested with 2 clients locally. Appeared to work as intended. 