### PR TITLE
final fix for starting player

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -48,10 +48,9 @@ class App extends Component {
         admin: true
       });
     });
-    socket.on("startGame", startingPlayer => {
+    socket.on("startGame", () => {
       this.setState({
-        playing: true,
-        startingPlayer: startingPlayer
+        playing: true
       });
     });
     socket.on("character", character => {
@@ -71,9 +70,10 @@ class App extends Component {
         setupInfo: setup
       });
     });
-    socket.on("gameInfo", gameInfo => {
+    socket.on("gameInfo", (gameInfo, startingPlayer) => {
       this.setState({
-        gameInfo: JSON.parse(gameInfo)
+        gameInfo: JSON.parse(gameInfo),
+        startingPlayer
       });
     });
   }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -48,9 +48,10 @@ class App extends Component {
         admin: true
       });
     });
-    socket.on("startGame", () => {
+    socket.on("startGame", startingPlayer => {
       this.setState({
-        playing: true
+        playing: true,
+        startingPlayer: startingPlayer
       });
     });
     socket.on("character", character => {
@@ -61,11 +62,6 @@ class App extends Component {
     socket.on("players", players => {
       this.setState({
         players
-      });
-    });
-    socket.on("startingPlayer", startingPlayer => {
-      this.setState({
-        startingPlayer
       });
     });
     socket.on("setupInfo", setupInfo => {

--- a/room.js
+++ b/room.js
@@ -110,19 +110,18 @@ class Room {
   async startGame() {
     const num = await generateNumber(0, 1000);
     const shuffledCards = shuffle(this.setup.characters, () => num / 1000);
+    const startingPlayer = this._determineStartingPlayer(this.players, num);
     for (let i = 0; i < shuffledCards.length; i++) {
       this._assignCharacter(this.players[i].socket, shuffledCards[i]);
     }
 
     switch (this.setup.game) {
       case "Avalon":
-        AvalonGameInfo(this.players, shuffledCards, num);
+        AvalonGameInfo(this.players, shuffledCards, num, startingPlayer);
         break;
     }
 
-    this.io
-      .to(this.setup.name)
-      .emit("startGame", this._determineStartingPlayer(this.players, num));
+    this.io.to(this.setup.name).emit("startGame");
   }
 
   _assignCharacter(socket, character) {
@@ -155,7 +154,7 @@ const getKnownAvalonPlayers = (knownList, players, deck) => {
   }, []);
 };
 
-const AvalonGameInfo = (players, deck, num) => {
+const AvalonGameInfo = (players, deck, num, startingPlayer) => {
   for (let i = 0; i < AvalonGamePlayerInfo.length; i++) {
     const playerData = AvalonGamePlayerInfo[i];
     const playerIndex = deck.findIndex(card => card == playerData.name);
@@ -165,7 +164,8 @@ const AvalonGameInfo = (players, deck, num) => {
       const shuffledRoles = shuffle(data, () => num / 1000);
       players[playerIndex].socket.emit(
         "gameInfo",
-        JSON.stringify(shuffledRoles)
+        JSON.stringify(shuffledRoles),
+        startingPlayer
       );
     }
   }

--- a/room.js
+++ b/room.js
@@ -122,8 +122,7 @@ class Room {
 
     this.io
       .to(this.setup.name)
-      .emit("startingPlayer", this._determineStartingPlayer(this.players, num));
-    this.io.to(this.setup.name).emit("startGame");
+      .emit("startGame", this._determineStartingPlayer(this.players, num));
   }
 
   _assignCharacter(socket, character) {
@@ -132,7 +131,7 @@ class Room {
 
   _determineStartingPlayer(players, num) {
     const shufflePlayers = shuffle(players, () => num / 1000);
-    return shufflePlayers[0];
+    return shufflePlayers[0].name;
   }
 }
 


### PR DESCRIPTION
Refactored to send staring player on `startGame` emit and also actually sending starting player name rather than the entire player socket. Tested with two clients successfully.